### PR TITLE
Adds support to bypass processing redirection

### DIFF
--- a/gateway_selector/public/js/base.js
+++ b/gateway_selector/public/js/base.js
@@ -126,6 +126,8 @@ frappe.gateway_selector._generic_embed = Class.extend({
   },
 
   process: function(data, callback) {
+    var base = this;
+
     // trigger payment gateway to use
     frappe.call({
       method: "gateway_selector.gateway_selector.doctype.gateway_selector_settings.gateway_selector_settings.get_url_from_gateway",
@@ -142,7 +144,9 @@ frappe.gateway_selector._generic_embed = Class.extend({
 			window.location.href = data.message
 
 			if ( base.gateway.name.toLowerCase() != "paypal" ) {
-				callback(null, result.message);
+        if (!base.gateway.muteProcessingCallback) {
+          callback(null, result.message);
+        }
 			}
 		})
 		.fail(function(xhr, textStatus) {


### PR DESCRIPTION
on embedded gateways(credit cards), once processing is done the embedded gateway takes over so it redirects the user to the success page. For paypal and affirm, this needs to be skipped as they have their own redirection.

This adds a "muteProcessingCallback" flag to control this behavior.

This is required to make the affirm billing validation fix work.